### PR TITLE
Tournaments Page Basic Template

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -261,28 +261,62 @@
 
 
 #tournaments .tournament-gallery {
-    height: 450px;
+    height: 400px;
     width: 100vw;
-    background-color: white; 
+    background-color: #00274C; 
     font-size: 40px;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}
+
+@media only screen and (max-width: 600px) {
+    #tournaments .tournament-gallery {
+        height: 400px;
+        width: 100vw;
+        background-color: #00274C; 
+        font-size: 20px;
+        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+    }
 }
 
 #tournaments .tournament-gallery .tournament-gallery2 .carousel {
     align-content: left; 
     width:50vw;
-    height:450px;
+    height:400px;
     float:left;
     font-size: 30px;
     text-align: center;
     vertical-align: middle;
     background-color: rgb(71, 70, 66);
     color: rgb(255, 203, 5);
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 }
 
 
 #tournaments .tournament-gallery .tournament-gallery2 .carousel .gallerydescrip{
     vertical-align: middle;
+}
+
+#tournaments .schedule_row {
+    background-color: rgb(46, 45, 44);
+    color: white;
+    height: 800px;
+    width: 100vw;
+
+}
+
+#tournaments .schedule_row .event {
+    background-color: rgb(71, 70, 66);
+    color: white;
+    height: 500px;
+    width: 100vw;
+    float: left;
+
+}
+
+#tournaments .schedule_row .heading {
+    color: white;
+    
+    
 }
 
 #tournaments .info_boxes_row {
@@ -304,7 +338,7 @@
     width: 100vw;
     height: 200px;
     position: relative;
-    font-size: 96px;
+    font-size: 90px;
     text-align: center;
     color: #00274C;
     padding-top: 100px;

--- a/styles.css
+++ b/styles.css
@@ -113,8 +113,8 @@
 
 #home .row2 {
     width: 100vw;
-    height: 80vh;
-    background-color: white;
+    height: 70vh;
+    background-color: #00274C;
     position: relative;
 }
 
@@ -257,7 +257,117 @@
 #updates .blog .blog-entries .blog-entry h2{
     font-size: 36px;
 }
-/* tournaments */
+/*-------------------- tournaments --------------------*/
+
+
+
+#tournaments .tournament-gallery {
+    background-color: white; 
+    font-size: 40px;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}
+
+
+
+#tournaments .tournament-row {
+    background-image: url("images/front_page_2.jpg");
+    background-attachment: fixed;
+}
+
+#tournament .galleryrow{
+    background-color: #00274C;
+    color: white; 
+    font-size: 900px;
+}
+
+#tournaments .tournament-row .tournament-heading {
+    width: 100vw;
+    height: 200px;
+    position: relative;
+    font-size: 96px;
+    text-align: center;
+    color: #00274C;
+    padding-top: 100px;
+}
+
+#tournaments .tournament-row .heading-bg {
+    background-image: url("images/front_page_2.jpg");
+
+    /* blur effect */
+    filter: blur(3px);
+    -webkit-filter:blur(3px);
+    
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover; 
+
+    height: 100%;
+    width: 50%;
+
+}
+
+#tournaments .tournament_intro {
+    position: relative;
+    font-size: 27px;
+    text-align: center;
+    color: #00274C;
+    margin-left: 50px;
+    margin-right: 50px;
+
+    padding-top: 50px;
+    padding-bottom: 50px;
+}
+
+#tournaments .tournament-gallery .carousel {
+    align-content: left; 
+}
+
+#tournaments .info_boxes_row {
+    width: 100vw;
+    height: 340px;
+    text-align: center;
+    box-shadow: 0px -2px 30px
+}
+
+/* Create three equal columns that floats next to each other */
+#tournaments .info_boxes_row .info_boxes_column {
+    float: left;
+    width: 33.33vw;
+    height: 340px;
+    background-color: #00274C;
+    color: white;
+    padding: 15px;
+}
+
+#tournaments .info_boxes_row .info_boxes_column .content {
+    text-align: left; 
+}
+
+#tournaments .info_boxes_row .info_boxes_column .content2 {
+    text-align: left; 
+}
+
+
+/* Clear floats after the columns */
+#tournaments .info_boxes_row .info_boxes_column:after {
+    content: "";
+    display: table;
+    clear: both;
+}
+
+/* Responsive layout - makes the three columns stack on top of each other instead of next to each other */
+@media screen and (max-width:600px) {
+    .column {
+      width: 100%;
+    }
+  }
+
+#tournaments .gallery {
+    width: 100vw;
+    text-align: center;
+    font-size: 48px;
+}
+
 
 
 

--- a/styles.css
+++ b/styles.css
@@ -260,13 +260,37 @@
 /*-------------------- tournaments --------------------*/
 
 
-
 #tournaments .tournament-gallery {
+    height: 450px;
+    width: 100vw;
     background-color: white; 
     font-size: 40px;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 }
 
+#tournaments .tournament-gallery .tournament-gallery2 .carousel {
+    align-content: left; 
+    width:50vw;
+    height:450px;
+    float:left;
+    font-size: 30px;
+    text-align: center;
+    vertical-align: middle;
+    background-color: rgb(71, 70, 66);
+    color: rgb(255, 203, 5);
+}
+
+
+#tournaments .tournament-gallery .tournament-gallery2 .carousel .gallerydescrip{
+    vertical-align: middle;
+}
+
+#tournaments .info_boxes_row {
+    width: 100vw;
+    height: 340px;
+    text-align: center;
+    box-shadow: 0px -2px 30px
+}
 
 
 #tournaments .tournament-row {
@@ -274,11 +298,7 @@
     background-attachment: fixed;
 }
 
-#tournament .galleryrow{
-    background-color: #00274C;
-    color: white; 
-    font-size: 900px;
-}
+
 
 #tournaments .tournament-row .tournament-heading {
     width: 100vw;
@@ -318,16 +338,7 @@
     padding-bottom: 50px;
 }
 
-#tournaments .tournament-gallery .carousel {
-    align-content: left; 
-}
 
-#tournaments .info_boxes_row {
-    width: 100vw;
-    height: 340px;
-    text-align: center;
-    box-shadow: 0px -2px 30px
-}
 
 /* Create three equal columns that floats next to each other */
 #tournaments .info_boxes_row .info_boxes_column {

--- a/tournaments.html
+++ b/tournaments.html
@@ -1,21 +1,154 @@
 <!DOCTYPE html>
 <html>
+   
+<style>
+* {
+    box-sizing: border-box;
+}
+</style>
+
 <head>
-<title>tournaments</title>
-<link href="styles.css" rel="stylesheet" type="text/css">
-<link href="https://fonts.googleapis.com/css?family=Oswald&display=swap" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    
+    <title>UM Open 2019</title>
+    <link href="styles.css" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Oswald&display=swap" rel="stylesheet">
 </head>
+
 <body id="tournaments">
 
-<a href="index.html"><img class="logo" src="images/baddylogoofficial.png"></a>
-<div class="nav-bar">
-    <a href="tournaments.html">TOURNAMENTS</a>
-    <a href="updates.html">UPDATES</a>
-</div>
+    <a href="index.html"><img class="logo" src="images/baddylogoofficial.png"></a>
+
+    <div class="nav-bar">
+        <a href="tournaments.html">UM OPEN 2019</a>
+        <a href="updates.html">UPDATES</a>
+    </div>
+
+    <div class="tournament-row">
+        <div class="heading-bg"></div>
+        <div class="tournament-heading">
+            UM Tournament 2019
+        </div>
+
+        <div class="tournament_intro">
+            The UofM Badminton Club is excited to host its second annual 
+            badminton tournament! The tournament allows for people of all skill levels
+            to play in a competitive setting fitting to their skill level. Cash prizes will
+            be provided. (placeholder message)
+        </div>
+    </div>
 
 
-<script>
-</script>
+    <div class="galleryrow">
+            2019 Spring UM Open Gallery
+    </div>
+
+    <div class="tournament-gallery">
+        <div class="carousel">
+            <script src="https://cdn.jsdelivr.net/npm/publicalbum@latest/embed-ui.min.js" async></script>
+            <div class="pa-carousel-widget" style="width:50%; height:480px; display:none;"
+            data-link="https://photos.app.goo.gl/zQrj9tUEPfRN4rVBA"
+            data-title="UM OPEN 2019"
+            data-description="50 new photos added to shared album">
+            <object data="https://lh3.googleusercontent.com/loXDo_-a2dRGlEyme730FlvInNbpNrnob0wa8qPKf-JZD4CrVD-0UjlA2rop9Re6TuSpuL6i-eThS3lMem-DpJKwTkGKofXfi_9n1Ql-TBfY5IQCJ8ThhgodxGtKkSrVJAoHkoBITQ=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/RTz7ALX0Df_tu8oZJAVNmcV4V45PA1Erig9BMLNhiJvN6ruhL5JDF614mMlHm4p2yDrF8Lb-0OOCW3E_X_-3zMciZ6mBqBKqN5ZY9oadiPTlc9OabtdEzcHuHqcFePKxB9XXjBa2sw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/JNnri5rdLkb-MU_eE_JBLK7STI1ARoR_Rywwzj0QYBE1yzxDdNNa4mhluMkPo1mHHpETgDr_J0F5_BHF7qXwLEF75_6bKlubuDrVmpzAqLLL5xNkBC7xpVuKoEKwgwFQdV6AZUHEGw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/d8NPYN-n2nJAv4KJcqF--Z_yaomX546kiYFqeWZLKT2e1NNrij9P0iXnRiPgPe8uN21UH1MaAW_EgGQrSUlLs_THPBTVQ1RNz5SjeK7Yf-PouFYo0INx8IBiEmsuIjNX23WwEOWmlA=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/yJGjDdvj-8fDSty7EvxC5RpSAGuQEDuopy9iky3qrCQ9a1KhZQy2WZozVYr6wrD9KqxoJdJackVRE0HUzkg0WUGGBz62XaIqaG0h7M7oV8zwTuWdP1KS0znIFrBPjVpZMkB0t28u9w=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/yO8Y2V4vbu7uMP6nCY02A8NNF-dj1XLCDoNOe_1acK79rsrbQ-emWILHY6ZptUZp2hSOAT8nyDPyKvIX8k3zADwdl2B4wFRc-kESe81jOVKKBpSogzDpsZPjxBC98-7aBxp9G6aXuQ=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/2j76CYefADOHnDUatKQhhDS5Zp9lXgi6wj9R8V1Lxiv5DOR3Q4VSBUfySGzLglxiT-gJFcMTSx3KKdoH2RzJtfMjgkbAGXpNtwAZOaAh6Nj4KKljFyx2Ii_40pLYAl7E7-IPi9FrZg=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/XjngG5GRWJF9w6bAM26WH6Zak0la6GSJvdSbIRnq9G5MCQw0jvKjLc5nf1LUGQzSg92Ss9FprN6QWBdAyOK-cff1d7CeJe0tpbZgBcheGQ-E-xqF41DybmYSd0V_1apJ2hB-qBgPQw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/gx92vkAVOnKyXxFh-WxWZVoGswkMVNnKcia4SUKtmQGIFtACtJdQpNNAP__rzzH0CWMXeqfjT-CbERZVHgPVICmrQakBRuZJcIE81TbwV0vYGMgtOvGq8l7I0hoaBZU7VYgK11iDwQ=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/sz85YaOw8yhCSg4cEDCytzCfU_hbENm35KmjBewWMjmbcK0JQszAjYtPpbMHlW00fYQRttj6X0Js3UJ_TblcASnpKELSo1QeGY-Z5gEYwVfV62KZ9gWgjRS11gFkNiHS1zr6o4Rp0w=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/O8fBXZJNxEAYXsbSL9hhO1Nktpkx_QMHhjYQLn0pgOPrVPpS36-2IS-mRaKr8GLiiq0-hddyWh6QAvVfDtOCSemQeIn5N9IJdEfSxMhbGXH8qEpFzGk8TYwdGc60BTEAxlKr9uVXhw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/Oezyk3C_AQmn_LxItSMcch3xzCM1WyjBbrmPJshacFn25-4vO_dKDk2RG-QMqwYcZesk5-2Foo9ci_4-R5Ahy4d1-Uttycr2_36jEFUV5MVcr1PACrLnwtDHgqPHoAtc0mh4UphNDw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/7TXIFekjgheNdq0ympCH3NItu-YrEask5l7XQ78KZEk44ktF1lgc7CdA4D6eyz-z5-lDXE3PPEaBnp60az-U8lXSwMlYctN0znasx5d0OuNbdZKFwa231UI-3kujtuEnxymbA2WkWw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/55ojdq6x9HTQkP9p3IOVfyXemtYlTtgKAVGVeyW1FqOB-FawkGS25F-XsdzjxvikzFR_5VrPUJkJcYYx6XhnVrXkXIRFbi8ST8s4grhL90UV8adA9yl0DcCzB2qZg55JVO0TFxDRNg=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/pxE2ztjaPUqua6gM7mPxMFQ_Bv2_3xzipMtYw9z6zXBN2aqukZrPPZ1HwB2uwi6lom4kbMJQ2cWbc6Cf-uJWzEDzBsqfacfkMq03-KEk1_Mw2E7E5KoDoHEy9wx_kFprTvFg4wRaww=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/7a0xlZ2WLDfNxYtORJNO4LDeMg9_VT7rk-ne-j0bHssjeN3RV_bpzhONKd9ABFU0GENVs7hvv9_mfEuIYjuM6gd3hNPmvgBlxAgBvsHBbDIp3ufe7XFcHCnVYZ9nvoOynlSInfXE_g=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/d12WwhDOgR_2vZfHSqHFE5gnFSmsqFJ_8vfaEYlodKWEMuaGe2wWNXyLVHK_gFjzMPmQKKRuvCPIY-X5cGx0-XUnXWcJ7sHmSa0Zjrbm1fHBQNqxr-9D6FRpjNMVaOu3JoH9y6sM4g=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/FyTKpP0XK1w-A6mpIr-n950JJwPliTE-lnrf_PJjehaDK8PDsA8kRcdPoOoSdUYv6hVwtnU8-TaXuyJ7u8SN0ZX6zcoIrdb72X_L_JwY39OrJ19RyJP9u2JTD1bRhBctlhuFtM20Og=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/B0NUFEH4MQK_1-ubU3e6KU34AigvoE8txIh0Nk2ISPVXCGZj8Y-iJz5lrvFPORJmwvLOkHO9efggNkJVlpWfijkyjTB2oUVKT5n-ky1u0bPjDtuZgcbDE_HIJhS3NuwjHmaU5453vQ=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/OwJIw_YCmJtmJKYnv06ZGnIp53XEqrZ1zg73KdCuI43-AWMzWlRCugPzR8PrzmWdRa1reU7LRt0NUEjxQhlvNyuUuFwMlb19ehFLJPh7_-hbFOY-SxG0Y9K1rZ2Fs-xB0-DfsW3NIg=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/lgpJUL6WhhzMh4E9mP8QYABV1fPuaxtBmN1IJFEQaGK8vs9Qd_cGAJ9bfcBkQwLP845D1qj1P3QlSevzqIAnl9rHHvaBRXccMQyG1mscnA8wg6L2cCd7HPR4xjjaAAvRnUDCJLe3WA=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/ayLnJhrL80QJo8MaA5LmKYO1UpeSQbI-Yc16YI1EzlIGs1SjJUL25vE2zLWY0X2ja2q14rdjf5xdO4jOqtNrG6u2sUi8_igkhCBrPTPEvTfTbCtiAQLzHrOy-VstMiFpmQgWKeoEDg=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/QeIUn5hdYjT7az1Pm_2QxVTkxHcgPl14iq-ZxyU72LFdB_6iiOEdK6bm1vPoHjnDxALctS_Igugis1egmxeXqdS4BRxEgVIqq6oRHT4wr6aE2wCgSio_weVGN8T8uN84TOjdeIFKWQ=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/XsnFiIXT7b8qcRem0JEpsq0SdDatYgYe43UxR3Sj1Cn2wgQoURFXaDR5eVKyv2VNDK6gQIhMKL_juPXssfavZDv7Rgf_fgk2Nn8_zOuUqY3Bir6KVTNz-dlC93i13aPPEvO9BFXAVQ=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/eZ0xJuSLOCRYL74VHPsFNTRO2ma41bRHRnNLjpVYMqeaPZc9Z6uNLXvVdKn8Z06kM8flxOVaCrEcmE6PvQ6I6z4pQctlHHGUAG11Wos-KyO4Rp-1h_U28KLlwEXbkbI6qfU-oIqfSw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/qGWXkq54NoKodT8fNDJgdaW1qajMEFQ1EwrWwIi0_JA3oks-3Seuv6DbH7N4dDxr-R0o33xH9b-4oP8P808LkmWhR8ybo1fVkzSSrpi3DfxvMKn6YSklp7-3U_ulSOZr5_4-Zjs__g=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/h4U5DMmYYk1CqxAXoCFRQiGvXZAPqqHKzjCBWqzd8OE88eYpFVav8loPR30ST4bhw359Q4llJLRpdW92-Cz0pn-P9uvkwU07mwonojS5tO10MLS36ZdSLmf4idx2IxzlGK_yUYgdlw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/vO_94PlPzY9beHQsQeMPn7s-5ZssDuDvZPqiKOzxITLkL-w66KQTpwPhnZtqHOlA2eHQKqnUnx4RiwmS6E5KP5bFqexuuYxzikKOEnD_nfgjkLV_xIiEt5BgOt6KNBLrkHDd5lswUw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/eHTev9asEinRI0LhtUGryuc2VOgsnLaowYaK3SXcZHJ6r3TX3iZHBnqt4oweladMh8x_fNbgwcDn-gNItiKuooH2Iqh90nK3T4KvAfBvwBGhwfS8LWnmT-yp8hzqBsl-KcxA4j57bQ=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/AUJr6RSGEm5FAiAxlMf15EjQaJtDjc2s7HqZ_NYj7Ho_R00m7arH802u6sUi1XiC9Mnamd3tGI5GEfZu5amkAMUAP9ooUDatlTmwfyDw6oV5hpxAGgHVGjUubqrgJkYsC33U4DIgMg=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/AfBOLg3L7LxIBpzkneIMImNGxZI5NifQ0lLPcuG34Mw7RbxePAJXUDgcc1ifqBaZUIj1KJbx322mnM-Nyd6VWEe_7JvbG97EQGbkxVdeILYdnfTYAL9xSBie9sZsjeDpaX-eM6zrjA=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/9R40cGOFmrfGGCk8fyWkPQY81_ctctGTUWYHoz6-e35-x1OuPyvAiu3rLMWkdJoLX_eJDkOwHK8omeJw02F5gwff7dkda0uqH-keu2AEYZ784c4KBTBAFIg5TG8GSSQx0am3zfyjhA=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/6RmuTxBJvWLSt3rVwPwyqo6-dHC7zQkMggVQauNz09NG2gLy3NECkBd3ueFfk3YghJbdW19a8AF66dJxjrhofYeo9BpAC5_dUA6DaV_8GgiBZbsOzJwhkOp1tcgV0YE1uf1hWv5Mqg=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/abTUFqOcFCmSzpm82vg0LaSWkM__d1q5HM-wCl76DURC6MxE3tILERN37Q8QCfc0tfxdwSRtZDbQx8oPWNp6OD0-Yq0eowztfGWT2eBZg_EtKdhN9uWlbLvLdyYirQU1cuNRQ_T89w=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/frOsz7Q6qYC789x4Se2VwPAkWyxf3J49lT7TSDB1dyO-63DIRHLQYbY9G6C8JzTTQoGOR7HKZ7Sb4tsqLuik7xabBBnbRxM4X2oy7azPbga6IZaBSPEBGWrCU3-XsEPLKBVF3xaNMA=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/y1UpBCvn0jdBnRIJMwyA2W3mv3na-jOi1Dod3-GEM7A6RPggCk2yEw2sH0DGE7m0NAKxX5S9pfI7b1ORZMAunbopYzQIGmdGhYfseG358ZUj1cWJm7m-ltju0VbTWvAJBRm-np-4tw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/RAzJWbdO6PbGCGZQgKcsf-QfpJBhC5LIY7yPfdij-f7GvYq5ft5gVL5dAGySJLaewijafBK4SotSdwxbjCI8E81nMJRQeSgVy9yZ_a2vCioZSCt7OB8KwXHd1ajNc6OKo6Y4h8-MZg=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/M52alzzCnnfjZpIF5k97i-smKmvESDYW8NQM5LPzvLlRXGlGWk0NQD9ZRsro1Vhig129x4jRhUEOtKXvqiPfJSmdBIwlzpM6dQ561PkFxJXRlMqHOyjLLFVa1mJY8jOFKb_JU_-Shw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/o9q4T9QpA6OsCQxSE-4UsAiLCeX2IvWKu19coNB5BvYJTjE9kMkG9YinaQ20yHBVuqI1ADMewlO-TkgnZ4852KKiSvD8thojkcnR5Q9DhUd7NkgqWUd90z3FoxOlqUCvA0fGT_tCtw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/UVqi0unETx7GGzxOeqOvvAPuv8msFUyceKT0KUEioRQV8yQvitIZqcbeZuH9Z2u0MS9Ri_RTK8tELh4h8Xwle-ND6P0iuI-okChJ9F5As7cmx_TgTEqFEgBoaWxeOMl0gPddpLJ_Pg=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/Zh_6a71TKy1X5bK3LYvJUExaCvN9eUfhWmgJLptd8V4DRHccMQ73VNuj3Y6ptWrfDQF0MJg0aJ_LuzLB_Iq1Gq2zvD5FqpZXKLHVV0F3tVUJ0fRPIitABRJbvwySyaIU0FcciSNJSw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/nzcoL1pYBrCzvC4Y7gR7RwTSMDdr_S26Q3cVfMd5RNPm3bySVH1DZweypS2BY45A_Pk328GhZhx86iygVAYbMcB6GlvRQQ6rjoy_id0C7buGzdGQTA-3ycaATEYMtj4uk1z2MgUJKQ=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/TxKIKPbusTL3vkWbZ1dV_iPU8QVw05NI9erjf1_WMu9ZdptDs8Sb-O75_zXuYpfXhWiQH-yZrsxnRo-NP70GurXBjb5P3_vOyDZCnilh8ocWQIEmR4P91s0QL_Yi4tL0sEoBG8rueA=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/eF9tz2zmaMVAIrVEGeqwsPR01p_1Dqb-MakHDQSfXO4gDViqvGNYvmf411YRiR_22TyaRKS6rzS6ig2uLCcvHoSojJRuyeaaRe9FSb3-Dq0lirMb4V35BwNIbC4n6s0b5Ni1PLilSw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/II5i8tHUZ_zxax3QIe0FVXDLq2LbSIS_UBv4_trSsNI2Sw5Woq1D5ht2TCmXMB75C-Jpr95gppMiQxG6IanwhDKUw0aLFfEzly4MWmjN_IK38K8nU6s9RA0NAs7aPaQOR1G1N-ELSA=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/6KF2dx1EVKUFsqvYTlerVUk6v3pha8itDT1cfNFrK8v3t384uUS-sms-m4gEY20hOjKgZNBq0fm2qidZrCVo9Pda482Ou-OT1C6TeawtLOMjhsiJePO4eenAyicQRXF-KYVZQcrhSw=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/vYT3WBmKD8ePyeka6ru6PrmNyPDdXhS9ebZJjNI0ReFN4ehSGVIWGj4sBXEn1Knr6qVjFd7qNlUr4Rp3NnEh0uIb4AsQvwNqZVo3rB7l0K0hMoc7zzkqBy0GyF-IVXeeb5vma2A89g=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/XNuIaFkokZN8YsnFAM-oXDXxpo6ecqzi3IeK8wKiR394FRLYUaXCXrYQt8IiL0eKf7u_vUIkZ5VtCy_qV24-d6osoL53ZgjO-x5ug5g3-tQIjgrymxnTSE8OAtzyvC_VfAuwqy_N3w=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/zU_Ru6SDfn11KR654zlrCgwhhKql2edyVkN8fOTXzgU0gG5CaglW9uElS0YGTJoWRsq2moaoCrUAC43-fPGy2vE8KM0JG47CcApMIMEaK_-0YKZHBcV3fjlUXyD4kH3qAAjMK-mMBg=w1920-h1080"></object>
+            <object data="https://lh3.googleusercontent.com/dVLhy3-QJqKmS9EvnDZ5ts-jjWncGj8qDUWrsyEd6rlCTEUF-CVbVCkiooVC7fIZijzoy48JdN2ylVET_f13Ly39wAznzhhsZ3CfJYtMKJ9Cl_KW-FYdd1cNxGJ8yCT3kbTFGX9w1Q=w1920-h1080"></object>
+            </div>
+        </div>
+
+    </div>
+    
+
+    <div class="info_boxes_row">
+        <div class="info_boxes_column">
+            <h2>
+                Location and Date
+            </h2>
+            <p class="content">
+                Location: North Campus Recreation Building, Hubbard Road, Ann Arbor, MI
+                 
+            </p>
+            <p class="content">
+            
+                Date: Friday November 20th - Sunday - November 22nd 
+            </p>
+            <p class="content">
+                Time: 11:00-am - 4:00pm 
+            </p>
+            
+            
+            
+        </div>
+        <div class="info_boxes_column">
+            <h2>
+                Map 
+            </h2>
+            <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m12!1m3!1d1788.0608385334922!2d-83.72080847371198!3d42.29512915137561!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!5e0!3m2!1sen!2sus!4v1569725320783!5m2!1sen!2sus" 
+            style="border-radius:20px" width="300" height="225" frameborder="1" style="border:0;" allowfullscreen=""></iframe>
+        </div>
+
+        <div class="info_boxes_column">
+            <h2>
+                Schedule
+            </h2>
+            <p>
+                Location: Ann Arbor,  MI
+                Time: 2:00am - 4:00am 
+            </p>
+        </div>
+    </div>
+
+
+    <script>
+    </script>
 
 </body>
+
 </html> 

--- a/tournaments.html
+++ b/tournaments.html
@@ -5,6 +5,7 @@
 * {
     box-sizing: border-box;
 }
+
 </style>
 
 <head>
@@ -13,9 +14,14 @@
     <title>UM Open 2019</title>
     <link href="styles.css" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Oswald&display=swap" rel="stylesheet">
+
+    
+    
 </head>
 
+
 <body id="tournaments">
+
 
     <a href="index.html"><img class="logo" src="images/baddylogoofficial.png"></a>
 
@@ -26,15 +32,14 @@
 
     <div class="tournament-row">
         <div class="heading-bg"></div>
-        <div class="tournament-heading">
+        <div class="tournament-heading" style=>
             UM Tournament 2019
         </div>
 
-        <div class="tournament_intro">
+        <div class="tournament_intro" style=>
             The UofM Badminton Club is excited to host its second annual 
             badminton tournament! The tournament allows for people of all skill levels
-            to play in a competitive setting fitting to their skill level. Cash prizes will
-            be provided. (placeholder message)
+            to play in a competitive setting fitting to their skill level. 
         </div>
     </div>
 
@@ -43,72 +48,141 @@
             2019 Spring UM Open Gallery
             
     </div>
-        <div class = "tournament-gallery">
+    <div class = "tournament-gallery">
         <div class="tournament-gallery2">
-            <div class="carousel">
-                <script src="https://cdn.jsdelivr.net/npm/publicalbum@latest/embed-ui.min.js" async></script>
-                <div class="pa-carousel-widget" style="width:50vw; height:480px; display:none;"
-                data-link="https://photos.app.goo.gl/zQrj9tUEPfRN4rVBA"
-                data-title="UM OPEN 2019"
-                data-description="50 new photos added to shared album">
-                <object data="https://lh3.googleusercontent.com/loXDo_-a2dRGlEyme730FlvInNbpNrnob0wa8qPKf-JZD4CrVD-0UjlA2rop9Re6TuSpuL6i-eThS3lMem-DpJKwTkGKofXfi_9n1Ql-TBfY5IQCJ8ThhgodxGtKkSrVJAoHkoBITQ=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/RTz7ALX0Df_tu8oZJAVNmcV4V45PA1Erig9BMLNhiJvN6ruhL5JDF614mMlHm4p2yDrF8Lb-0OOCW3E_X_-3zMciZ6mBqBKqN5ZY9oadiPTlc9OabtdEzcHuHqcFePKxB9XXjBa2sw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/JNnri5rdLkb-MU_eE_JBLK7STI1ARoR_Rywwzj0QYBE1yzxDdNNa4mhluMkPo1mHHpETgDr_J0F5_BHF7qXwLEF75_6bKlubuDrVmpzAqLLL5xNkBC7xpVuKoEKwgwFQdV6AZUHEGw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/d8NPYN-n2nJAv4KJcqF--Z_yaomX546kiYFqeWZLKT2e1NNrij9P0iXnRiPgPe8uN21UH1MaAW_EgGQrSUlLs_THPBTVQ1RNz5SjeK7Yf-PouFYo0INx8IBiEmsuIjNX23WwEOWmlA=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/yJGjDdvj-8fDSty7EvxC5RpSAGuQEDuopy9iky3qrCQ9a1KhZQy2WZozVYr6wrD9KqxoJdJackVRE0HUzkg0WUGGBz62XaIqaG0h7M7oV8zwTuWdP1KS0znIFrBPjVpZMkB0t28u9w=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/yO8Y2V4vbu7uMP6nCY02A8NNF-dj1XLCDoNOe_1acK79rsrbQ-emWILHY6ZptUZp2hSOAT8nyDPyKvIX8k3zADwdl2B4wFRc-kESe81jOVKKBpSogzDpsZPjxBC98-7aBxp9G6aXuQ=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/2j76CYefADOHnDUatKQhhDS5Zp9lXgi6wj9R8V1Lxiv5DOR3Q4VSBUfySGzLglxiT-gJFcMTSx3KKdoH2RzJtfMjgkbAGXpNtwAZOaAh6Nj4KKljFyx2Ii_40pLYAl7E7-IPi9FrZg=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/XjngG5GRWJF9w6bAM26WH6Zak0la6GSJvdSbIRnq9G5MCQw0jvKjLc5nf1LUGQzSg92Ss9FprN6QWBdAyOK-cff1d7CeJe0tpbZgBcheGQ-E-xqF41DybmYSd0V_1apJ2hB-qBgPQw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/gx92vkAVOnKyXxFh-WxWZVoGswkMVNnKcia4SUKtmQGIFtACtJdQpNNAP__rzzH0CWMXeqfjT-CbERZVHgPVICmrQakBRuZJcIE81TbwV0vYGMgtOvGq8l7I0hoaBZU7VYgK11iDwQ=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/sz85YaOw8yhCSg4cEDCytzCfU_hbENm35KmjBewWMjmbcK0JQszAjYtPpbMHlW00fYQRttj6X0Js3UJ_TblcASnpKELSo1QeGY-Z5gEYwVfV62KZ9gWgjRS11gFkNiHS1zr6o4Rp0w=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/O8fBXZJNxEAYXsbSL9hhO1Nktpkx_QMHhjYQLn0pgOPrVPpS36-2IS-mRaKr8GLiiq0-hddyWh6QAvVfDtOCSemQeIn5N9IJdEfSxMhbGXH8qEpFzGk8TYwdGc60BTEAxlKr9uVXhw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/Oezyk3C_AQmn_LxItSMcch3xzCM1WyjBbrmPJshacFn25-4vO_dKDk2RG-QMqwYcZesk5-2Foo9ci_4-R5Ahy4d1-Uttycr2_36jEFUV5MVcr1PACrLnwtDHgqPHoAtc0mh4UphNDw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/7TXIFekjgheNdq0ympCH3NItu-YrEask5l7XQ78KZEk44ktF1lgc7CdA4D6eyz-z5-lDXE3PPEaBnp60az-U8lXSwMlYctN0znasx5d0OuNbdZKFwa231UI-3kujtuEnxymbA2WkWw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/55ojdq6x9HTQkP9p3IOVfyXemtYlTtgKAVGVeyW1FqOB-FawkGS25F-XsdzjxvikzFR_5VrPUJkJcYYx6XhnVrXkXIRFbi8ST8s4grhL90UV8adA9yl0DcCzB2qZg55JVO0TFxDRNg=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/pxE2ztjaPUqua6gM7mPxMFQ_Bv2_3xzipMtYw9z6zXBN2aqukZrPPZ1HwB2uwi6lom4kbMJQ2cWbc6Cf-uJWzEDzBsqfacfkMq03-KEk1_Mw2E7E5KoDoHEy9wx_kFprTvFg4wRaww=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/7a0xlZ2WLDfNxYtORJNO4LDeMg9_VT7rk-ne-j0bHssjeN3RV_bpzhONKd9ABFU0GENVs7hvv9_mfEuIYjuM6gd3hNPmvgBlxAgBvsHBbDIp3ufe7XFcHCnVYZ9nvoOynlSInfXE_g=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/d12WwhDOgR_2vZfHSqHFE5gnFSmsqFJ_8vfaEYlodKWEMuaGe2wWNXyLVHK_gFjzMPmQKKRuvCPIY-X5cGx0-XUnXWcJ7sHmSa0Zjrbm1fHBQNqxr-9D6FRpjNMVaOu3JoH9y6sM4g=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/FyTKpP0XK1w-A6mpIr-n950JJwPliTE-lnrf_PJjehaDK8PDsA8kRcdPoOoSdUYv6hVwtnU8-TaXuyJ7u8SN0ZX6zcoIrdb72X_L_JwY39OrJ19RyJP9u2JTD1bRhBctlhuFtM20Og=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/B0NUFEH4MQK_1-ubU3e6KU34AigvoE8txIh0Nk2ISPVXCGZj8Y-iJz5lrvFPORJmwvLOkHO9efggNkJVlpWfijkyjTB2oUVKT5n-ky1u0bPjDtuZgcbDE_HIJhS3NuwjHmaU5453vQ=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/OwJIw_YCmJtmJKYnv06ZGnIp53XEqrZ1zg73KdCuI43-AWMzWlRCugPzR8PrzmWdRa1reU7LRt0NUEjxQhlvNyuUuFwMlb19ehFLJPh7_-hbFOY-SxG0Y9K1rZ2Fs-xB0-DfsW3NIg=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/lgpJUL6WhhzMh4E9mP8QYABV1fPuaxtBmN1IJFEQaGK8vs9Qd_cGAJ9bfcBkQwLP845D1qj1P3QlSevzqIAnl9rHHvaBRXccMQyG1mscnA8wg6L2cCd7HPR4xjjaAAvRnUDCJLe3WA=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/ayLnJhrL80QJo8MaA5LmKYO1UpeSQbI-Yc16YI1EzlIGs1SjJUL25vE2zLWY0X2ja2q14rdjf5xdO4jOqtNrG6u2sUi8_igkhCBrPTPEvTfTbCtiAQLzHrOy-VstMiFpmQgWKeoEDg=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/QeIUn5hdYjT7az1Pm_2QxVTkxHcgPl14iq-ZxyU72LFdB_6iiOEdK6bm1vPoHjnDxALctS_Igugis1egmxeXqdS4BRxEgVIqq6oRHT4wr6aE2wCgSio_weVGN8T8uN84TOjdeIFKWQ=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/XsnFiIXT7b8qcRem0JEpsq0SdDatYgYe43UxR3Sj1Cn2wgQoURFXaDR5eVKyv2VNDK6gQIhMKL_juPXssfavZDv7Rgf_fgk2Nn8_zOuUqY3Bir6KVTNz-dlC93i13aPPEvO9BFXAVQ=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/eZ0xJuSLOCRYL74VHPsFNTRO2ma41bRHRnNLjpVYMqeaPZc9Z6uNLXvVdKn8Z06kM8flxOVaCrEcmE6PvQ6I6z4pQctlHHGUAG11Wos-KyO4Rp-1h_U28KLlwEXbkbI6qfU-oIqfSw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/qGWXkq54NoKodT8fNDJgdaW1qajMEFQ1EwrWwIi0_JA3oks-3Seuv6DbH7N4dDxr-R0o33xH9b-4oP8P808LkmWhR8ybo1fVkzSSrpi3DfxvMKn6YSklp7-3U_ulSOZr5_4-Zjs__g=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/h4U5DMmYYk1CqxAXoCFRQiGvXZAPqqHKzjCBWqzd8OE88eYpFVav8loPR30ST4bhw359Q4llJLRpdW92-Cz0pn-P9uvkwU07mwonojS5tO10MLS36ZdSLmf4idx2IxzlGK_yUYgdlw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/vO_94PlPzY9beHQsQeMPn7s-5ZssDuDvZPqiKOzxITLkL-w66KQTpwPhnZtqHOlA2eHQKqnUnx4RiwmS6E5KP5bFqexuuYxzikKOEnD_nfgjkLV_xIiEt5BgOt6KNBLrkHDd5lswUw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/eHTev9asEinRI0LhtUGryuc2VOgsnLaowYaK3SXcZHJ6r3TX3iZHBnqt4oweladMh8x_fNbgwcDn-gNItiKuooH2Iqh90nK3T4KvAfBvwBGhwfS8LWnmT-yp8hzqBsl-KcxA4j57bQ=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/AUJr6RSGEm5FAiAxlMf15EjQaJtDjc2s7HqZ_NYj7Ho_R00m7arH802u6sUi1XiC9Mnamd3tGI5GEfZu5amkAMUAP9ooUDatlTmwfyDw6oV5hpxAGgHVGjUubqrgJkYsC33U4DIgMg=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/AfBOLg3L7LxIBpzkneIMImNGxZI5NifQ0lLPcuG34Mw7RbxePAJXUDgcc1ifqBaZUIj1KJbx322mnM-Nyd6VWEe_7JvbG97EQGbkxVdeILYdnfTYAL9xSBie9sZsjeDpaX-eM6zrjA=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/9R40cGOFmrfGGCk8fyWkPQY81_ctctGTUWYHoz6-e35-x1OuPyvAiu3rLMWkdJoLX_eJDkOwHK8omeJw02F5gwff7dkda0uqH-keu2AEYZ784c4KBTBAFIg5TG8GSSQx0am3zfyjhA=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/6RmuTxBJvWLSt3rVwPwyqo6-dHC7zQkMggVQauNz09NG2gLy3NECkBd3ueFfk3YghJbdW19a8AF66dJxjrhofYeo9BpAC5_dUA6DaV_8GgiBZbsOzJwhkOp1tcgV0YE1uf1hWv5Mqg=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/abTUFqOcFCmSzpm82vg0LaSWkM__d1q5HM-wCl76DURC6MxE3tILERN37Q8QCfc0tfxdwSRtZDbQx8oPWNp6OD0-Yq0eowztfGWT2eBZg_EtKdhN9uWlbLvLdyYirQU1cuNRQ_T89w=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/frOsz7Q6qYC789x4Se2VwPAkWyxf3J49lT7TSDB1dyO-63DIRHLQYbY9G6C8JzTTQoGOR7HKZ7Sb4tsqLuik7xabBBnbRxM4X2oy7azPbga6IZaBSPEBGWrCU3-XsEPLKBVF3xaNMA=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/y1UpBCvn0jdBnRIJMwyA2W3mv3na-jOi1Dod3-GEM7A6RPggCk2yEw2sH0DGE7m0NAKxX5S9pfI7b1ORZMAunbopYzQIGmdGhYfseG358ZUj1cWJm7m-ltju0VbTWvAJBRm-np-4tw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/RAzJWbdO6PbGCGZQgKcsf-QfpJBhC5LIY7yPfdij-f7GvYq5ft5gVL5dAGySJLaewijafBK4SotSdwxbjCI8E81nMJRQeSgVy9yZ_a2vCioZSCt7OB8KwXHd1ajNc6OKo6Y4h8-MZg=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/M52alzzCnnfjZpIF5k97i-smKmvESDYW8NQM5LPzvLlRXGlGWk0NQD9ZRsro1Vhig129x4jRhUEOtKXvqiPfJSmdBIwlzpM6dQ561PkFxJXRlMqHOyjLLFVa1mJY8jOFKb_JU_-Shw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/o9q4T9QpA6OsCQxSE-4UsAiLCeX2IvWKu19coNB5BvYJTjE9kMkG9YinaQ20yHBVuqI1ADMewlO-TkgnZ4852KKiSvD8thojkcnR5Q9DhUd7NkgqWUd90z3FoxOlqUCvA0fGT_tCtw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/UVqi0unETx7GGzxOeqOvvAPuv8msFUyceKT0KUEioRQV8yQvitIZqcbeZuH9Z2u0MS9Ri_RTK8tELh4h8Xwle-ND6P0iuI-okChJ9F5As7cmx_TgTEqFEgBoaWxeOMl0gPddpLJ_Pg=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/Zh_6a71TKy1X5bK3LYvJUExaCvN9eUfhWmgJLptd8V4DRHccMQ73VNuj3Y6ptWrfDQF0MJg0aJ_LuzLB_Iq1Gq2zvD5FqpZXKLHVV0F3tVUJ0fRPIitABRJbvwySyaIU0FcciSNJSw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/nzcoL1pYBrCzvC4Y7gR7RwTSMDdr_S26Q3cVfMd5RNPm3bySVH1DZweypS2BY45A_Pk328GhZhx86iygVAYbMcB6GlvRQQ6rjoy_id0C7buGzdGQTA-3ycaATEYMtj4uk1z2MgUJKQ=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/TxKIKPbusTL3vkWbZ1dV_iPU8QVw05NI9erjf1_WMu9ZdptDs8Sb-O75_zXuYpfXhWiQH-yZrsxnRo-NP70GurXBjb5P3_vOyDZCnilh8ocWQIEmR4P91s0QL_Yi4tL0sEoBG8rueA=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/eF9tz2zmaMVAIrVEGeqwsPR01p_1Dqb-MakHDQSfXO4gDViqvGNYvmf411YRiR_22TyaRKS6rzS6ig2uLCcvHoSojJRuyeaaRe9FSb3-Dq0lirMb4V35BwNIbC4n6s0b5Ni1PLilSw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/II5i8tHUZ_zxax3QIe0FVXDLq2LbSIS_UBv4_trSsNI2Sw5Woq1D5ht2TCmXMB75C-Jpr95gppMiQxG6IanwhDKUw0aLFfEzly4MWmjN_IK38K8nU6s9RA0NAs7aPaQOR1G1N-ELSA=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/6KF2dx1EVKUFsqvYTlerVUk6v3pha8itDT1cfNFrK8v3t384uUS-sms-m4gEY20hOjKgZNBq0fm2qidZrCVo9Pda482Ou-OT1C6TeawtLOMjhsiJePO4eenAyicQRXF-KYVZQcrhSw=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/vYT3WBmKD8ePyeka6ru6PrmNyPDdXhS9ebZJjNI0ReFN4ehSGVIWGj4sBXEn1Knr6qVjFd7qNlUr4Rp3NnEh0uIb4AsQvwNqZVo3rB7l0K0hMoc7zzkqBy0GyF-IVXeeb5vma2A89g=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/XNuIaFkokZN8YsnFAM-oXDXxpo6ecqzi3IeK8wKiR394FRLYUaXCXrYQt8IiL0eKf7u_vUIkZ5VtCy_qV24-d6osoL53ZgjO-x5ug5g3-tQIjgrymxnTSE8OAtzyvC_VfAuwqy_N3w=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/zU_Ru6SDfn11KR654zlrCgwhhKql2edyVkN8fOTXzgU0gG5CaglW9uElS0YGTJoWRsq2moaoCrUAC43-fPGy2vE8KM0JG47CcApMIMEaK_-0YKZHBcV3fjlUXyD4kH3qAAjMK-mMBg=w1920-h1080"></object>
-                <object data="https://lh3.googleusercontent.com/dVLhy3-QJqKmS9EvnDZ5ts-jjWncGj8qDUWrsyEd6rlCTEUF-CVbVCkiooVC7fIZijzoy48JdN2ylVET_f13Ly39wAznzhhsZ3CfJYtMKJ9Cl_KW-FYdd1cNxGJ8yCT3kbTFGX9w1Q=w1920-h1080"></object>
+                <div class="carousel">
+                    <script src="https://cdn.jsdelivr.net/npm/publicalbum@latest/embed-ui.min.js" async></script>
+                    <div class="pa-carousel-widget" style="width:50vw; height:400px; display:none;"
+                    data-link="https://photos.app.goo.gl/zQrj9tUEPfRN4rVBA"
+                    data-title="UM OPEN 2019"
+                    data-description="50 new photos added to shared album">
+                    <object data="https://lh3.googleusercontent.com/loXDo_-a2dRGlEyme730FlvInNbpNrnob0wa8qPKf-JZD4CrVD-0UjlA2rop9Re6TuSpuL6i-eThS3lMem-DpJKwTkGKofXfi_9n1Ql-TBfY5IQCJ8ThhgodxGtKkSrVJAoHkoBITQ=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/RTz7ALX0Df_tu8oZJAVNmcV4V45PA1Erig9BMLNhiJvN6ruhL5JDF614mMlHm4p2yDrF8Lb-0OOCW3E_X_-3zMciZ6mBqBKqN5ZY9oadiPTlc9OabtdEzcHuHqcFePKxB9XXjBa2sw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/JNnri5rdLkb-MU_eE_JBLK7STI1ARoR_Rywwzj0QYBE1yzxDdNNa4mhluMkPo1mHHpETgDr_J0F5_BHF7qXwLEF75_6bKlubuDrVmpzAqLLL5xNkBC7xpVuKoEKwgwFQdV6AZUHEGw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/d8NPYN-n2nJAv4KJcqF--Z_yaomX546kiYFqeWZLKT2e1NNrij9P0iXnRiPgPe8uN21UH1MaAW_EgGQrSUlLs_THPBTVQ1RNz5SjeK7Yf-PouFYo0INx8IBiEmsuIjNX23WwEOWmlA=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/yJGjDdvj-8fDSty7EvxC5RpSAGuQEDuopy9iky3qrCQ9a1KhZQy2WZozVYr6wrD9KqxoJdJackVRE0HUzkg0WUGGBz62XaIqaG0h7M7oV8zwTuWdP1KS0znIFrBPjVpZMkB0t28u9w=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/yO8Y2V4vbu7uMP6nCY02A8NNF-dj1XLCDoNOe_1acK79rsrbQ-emWILHY6ZptUZp2hSOAT8nyDPyKvIX8k3zADwdl2B4wFRc-kESe81jOVKKBpSogzDpsZPjxBC98-7aBxp9G6aXuQ=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/2j76CYefADOHnDUatKQhhDS5Zp9lXgi6wj9R8V1Lxiv5DOR3Q4VSBUfySGzLglxiT-gJFcMTSx3KKdoH2RzJtfMjgkbAGXpNtwAZOaAh6Nj4KKljFyx2Ii_40pLYAl7E7-IPi9FrZg=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/XjngG5GRWJF9w6bAM26WH6Zak0la6GSJvdSbIRnq9G5MCQw0jvKjLc5nf1LUGQzSg92Ss9FprN6QWBdAyOK-cff1d7CeJe0tpbZgBcheGQ-E-xqF41DybmYSd0V_1apJ2hB-qBgPQw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/gx92vkAVOnKyXxFh-WxWZVoGswkMVNnKcia4SUKtmQGIFtACtJdQpNNAP__rzzH0CWMXeqfjT-CbERZVHgPVICmrQakBRuZJcIE81TbwV0vYGMgtOvGq8l7I0hoaBZU7VYgK11iDwQ=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/sz85YaOw8yhCSg4cEDCytzCfU_hbENm35KmjBewWMjmbcK0JQszAjYtPpbMHlW00fYQRttj6X0Js3UJ_TblcASnpKELSo1QeGY-Z5gEYwVfV62KZ9gWgjRS11gFkNiHS1zr6o4Rp0w=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/O8fBXZJNxEAYXsbSL9hhO1Nktpkx_QMHhjYQLn0pgOPrVPpS36-2IS-mRaKr8GLiiq0-hddyWh6QAvVfDtOCSemQeIn5N9IJdEfSxMhbGXH8qEpFzGk8TYwdGc60BTEAxlKr9uVXhw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/Oezyk3C_AQmn_LxItSMcch3xzCM1WyjBbrmPJshacFn25-4vO_dKDk2RG-QMqwYcZesk5-2Foo9ci_4-R5Ahy4d1-Uttycr2_36jEFUV5MVcr1PACrLnwtDHgqPHoAtc0mh4UphNDw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/7TXIFekjgheNdq0ympCH3NItu-YrEask5l7XQ78KZEk44ktF1lgc7CdA4D6eyz-z5-lDXE3PPEaBnp60az-U8lXSwMlYctN0znasx5d0OuNbdZKFwa231UI-3kujtuEnxymbA2WkWw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/55ojdq6x9HTQkP9p3IOVfyXemtYlTtgKAVGVeyW1FqOB-FawkGS25F-XsdzjxvikzFR_5VrPUJkJcYYx6XhnVrXkXIRFbi8ST8s4grhL90UV8adA9yl0DcCzB2qZg55JVO0TFxDRNg=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/pxE2ztjaPUqua6gM7mPxMFQ_Bv2_3xzipMtYw9z6zXBN2aqukZrPPZ1HwB2uwi6lom4kbMJQ2cWbc6Cf-uJWzEDzBsqfacfkMq03-KEk1_Mw2E7E5KoDoHEy9wx_kFprTvFg4wRaww=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/7a0xlZ2WLDfNxYtORJNO4LDeMg9_VT7rk-ne-j0bHssjeN3RV_bpzhONKd9ABFU0GENVs7hvv9_mfEuIYjuM6gd3hNPmvgBlxAgBvsHBbDIp3ufe7XFcHCnVYZ9nvoOynlSInfXE_g=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/d12WwhDOgR_2vZfHSqHFE5gnFSmsqFJ_8vfaEYlodKWEMuaGe2wWNXyLVHK_gFjzMPmQKKRuvCPIY-X5cGx0-XUnXWcJ7sHmSa0Zjrbm1fHBQNqxr-9D6FRpjNMVaOu3JoH9y6sM4g=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/FyTKpP0XK1w-A6mpIr-n950JJwPliTE-lnrf_PJjehaDK8PDsA8kRcdPoOoSdUYv6hVwtnU8-TaXuyJ7u8SN0ZX6zcoIrdb72X_L_JwY39OrJ19RyJP9u2JTD1bRhBctlhuFtM20Og=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/B0NUFEH4MQK_1-ubU3e6KU34AigvoE8txIh0Nk2ISPVXCGZj8Y-iJz5lrvFPORJmwvLOkHO9efggNkJVlpWfijkyjTB2oUVKT5n-ky1u0bPjDtuZgcbDE_HIJhS3NuwjHmaU5453vQ=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/OwJIw_YCmJtmJKYnv06ZGnIp53XEqrZ1zg73KdCuI43-AWMzWlRCugPzR8PrzmWdRa1reU7LRt0NUEjxQhlvNyuUuFwMlb19ehFLJPh7_-hbFOY-SxG0Y9K1rZ2Fs-xB0-DfsW3NIg=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/lgpJUL6WhhzMh4E9mP8QYABV1fPuaxtBmN1IJFEQaGK8vs9Qd_cGAJ9bfcBkQwLP845D1qj1P3QlSevzqIAnl9rHHvaBRXccMQyG1mscnA8wg6L2cCd7HPR4xjjaAAvRnUDCJLe3WA=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/ayLnJhrL80QJo8MaA5LmKYO1UpeSQbI-Yc16YI1EzlIGs1SjJUL25vE2zLWY0X2ja2q14rdjf5xdO4jOqtNrG6u2sUi8_igkhCBrPTPEvTfTbCtiAQLzHrOy-VstMiFpmQgWKeoEDg=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/QeIUn5hdYjT7az1Pm_2QxVTkxHcgPl14iq-ZxyU72LFdB_6iiOEdK6bm1vPoHjnDxALctS_Igugis1egmxeXqdS4BRxEgVIqq6oRHT4wr6aE2wCgSio_weVGN8T8uN84TOjdeIFKWQ=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/XsnFiIXT7b8qcRem0JEpsq0SdDatYgYe43UxR3Sj1Cn2wgQoURFXaDR5eVKyv2VNDK6gQIhMKL_juPXssfavZDv7Rgf_fgk2Nn8_zOuUqY3Bir6KVTNz-dlC93i13aPPEvO9BFXAVQ=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/eZ0xJuSLOCRYL74VHPsFNTRO2ma41bRHRnNLjpVYMqeaPZc9Z6uNLXvVdKn8Z06kM8flxOVaCrEcmE6PvQ6I6z4pQctlHHGUAG11Wos-KyO4Rp-1h_U28KLlwEXbkbI6qfU-oIqfSw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/qGWXkq54NoKodT8fNDJgdaW1qajMEFQ1EwrWwIi0_JA3oks-3Seuv6DbH7N4dDxr-R0o33xH9b-4oP8P808LkmWhR8ybo1fVkzSSrpi3DfxvMKn6YSklp7-3U_ulSOZr5_4-Zjs__g=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/h4U5DMmYYk1CqxAXoCFRQiGvXZAPqqHKzjCBWqzd8OE88eYpFVav8loPR30ST4bhw359Q4llJLRpdW92-Cz0pn-P9uvkwU07mwonojS5tO10MLS36ZdSLmf4idx2IxzlGK_yUYgdlw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/vO_94PlPzY9beHQsQeMPn7s-5ZssDuDvZPqiKOzxITLkL-w66KQTpwPhnZtqHOlA2eHQKqnUnx4RiwmS6E5KP5bFqexuuYxzikKOEnD_nfgjkLV_xIiEt5BgOt6KNBLrkHDd5lswUw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/eHTev9asEinRI0LhtUGryuc2VOgsnLaowYaK3SXcZHJ6r3TX3iZHBnqt4oweladMh8x_fNbgwcDn-gNItiKuooH2Iqh90nK3T4KvAfBvwBGhwfS8LWnmT-yp8hzqBsl-KcxA4j57bQ=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/AUJr6RSGEm5FAiAxlMf15EjQaJtDjc2s7HqZ_NYj7Ho_R00m7arH802u6sUi1XiC9Mnamd3tGI5GEfZu5amkAMUAP9ooUDatlTmwfyDw6oV5hpxAGgHVGjUubqrgJkYsC33U4DIgMg=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/AfBOLg3L7LxIBpzkneIMImNGxZI5NifQ0lLPcuG34Mw7RbxePAJXUDgcc1ifqBaZUIj1KJbx322mnM-Nyd6VWEe_7JvbG97EQGbkxVdeILYdnfTYAL9xSBie9sZsjeDpaX-eM6zrjA=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/9R40cGOFmrfGGCk8fyWkPQY81_ctctGTUWYHoz6-e35-x1OuPyvAiu3rLMWkdJoLX_eJDkOwHK8omeJw02F5gwff7dkda0uqH-keu2AEYZ784c4KBTBAFIg5TG8GSSQx0am3zfyjhA=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/6RmuTxBJvWLSt3rVwPwyqo6-dHC7zQkMggVQauNz09NG2gLy3NECkBd3ueFfk3YghJbdW19a8AF66dJxjrhofYeo9BpAC5_dUA6DaV_8GgiBZbsOzJwhkOp1tcgV0YE1uf1hWv5Mqg=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/abTUFqOcFCmSzpm82vg0LaSWkM__d1q5HM-wCl76DURC6MxE3tILERN37Q8QCfc0tfxdwSRtZDbQx8oPWNp6OD0-Yq0eowztfGWT2eBZg_EtKdhN9uWlbLvLdyYirQU1cuNRQ_T89w=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/frOsz7Q6qYC789x4Se2VwPAkWyxf3J49lT7TSDB1dyO-63DIRHLQYbY9G6C8JzTTQoGOR7HKZ7Sb4tsqLuik7xabBBnbRxM4X2oy7azPbga6IZaBSPEBGWrCU3-XsEPLKBVF3xaNMA=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/y1UpBCvn0jdBnRIJMwyA2W3mv3na-jOi1Dod3-GEM7A6RPggCk2yEw2sH0DGE7m0NAKxX5S9pfI7b1ORZMAunbopYzQIGmdGhYfseG358ZUj1cWJm7m-ltju0VbTWvAJBRm-np-4tw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/RAzJWbdO6PbGCGZQgKcsf-QfpJBhC5LIY7yPfdij-f7GvYq5ft5gVL5dAGySJLaewijafBK4SotSdwxbjCI8E81nMJRQeSgVy9yZ_a2vCioZSCt7OB8KwXHd1ajNc6OKo6Y4h8-MZg=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/M52alzzCnnfjZpIF5k97i-smKmvESDYW8NQM5LPzvLlRXGlGWk0NQD9ZRsro1Vhig129x4jRhUEOtKXvqiPfJSmdBIwlzpM6dQ561PkFxJXRlMqHOyjLLFVa1mJY8jOFKb_JU_-Shw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/o9q4T9QpA6OsCQxSE-4UsAiLCeX2IvWKu19coNB5BvYJTjE9kMkG9YinaQ20yHBVuqI1ADMewlO-TkgnZ4852KKiSvD8thojkcnR5Q9DhUd7NkgqWUd90z3FoxOlqUCvA0fGT_tCtw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/UVqi0unETx7GGzxOeqOvvAPuv8msFUyceKT0KUEioRQV8yQvitIZqcbeZuH9Z2u0MS9Ri_RTK8tELh4h8Xwle-ND6P0iuI-okChJ9F5As7cmx_TgTEqFEgBoaWxeOMl0gPddpLJ_Pg=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/Zh_6a71TKy1X5bK3LYvJUExaCvN9eUfhWmgJLptd8V4DRHccMQ73VNuj3Y6ptWrfDQF0MJg0aJ_LuzLB_Iq1Gq2zvD5FqpZXKLHVV0F3tVUJ0fRPIitABRJbvwySyaIU0FcciSNJSw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/nzcoL1pYBrCzvC4Y7gR7RwTSMDdr_S26Q3cVfMd5RNPm3bySVH1DZweypS2BY45A_Pk328GhZhx86iygVAYbMcB6GlvRQQ6rjoy_id0C7buGzdGQTA-3ycaATEYMtj4uk1z2MgUJKQ=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/TxKIKPbusTL3vkWbZ1dV_iPU8QVw05NI9erjf1_WMu9ZdptDs8Sb-O75_zXuYpfXhWiQH-yZrsxnRo-NP70GurXBjb5P3_vOyDZCnilh8ocWQIEmR4P91s0QL_Yi4tL0sEoBG8rueA=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/eF9tz2zmaMVAIrVEGeqwsPR01p_1Dqb-MakHDQSfXO4gDViqvGNYvmf411YRiR_22TyaRKS6rzS6ig2uLCcvHoSojJRuyeaaRe9FSb3-Dq0lirMb4V35BwNIbC4n6s0b5Ni1PLilSw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/II5i8tHUZ_zxax3QIe0FVXDLq2LbSIS_UBv4_trSsNI2Sw5Woq1D5ht2TCmXMB75C-Jpr95gppMiQxG6IanwhDKUw0aLFfEzly4MWmjN_IK38K8nU6s9RA0NAs7aPaQOR1G1N-ELSA=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/6KF2dx1EVKUFsqvYTlerVUk6v3pha8itDT1cfNFrK8v3t384uUS-sms-m4gEY20hOjKgZNBq0fm2qidZrCVo9Pda482Ou-OT1C6TeawtLOMjhsiJePO4eenAyicQRXF-KYVZQcrhSw=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/vYT3WBmKD8ePyeka6ru6PrmNyPDdXhS9ebZJjNI0ReFN4ehSGVIWGj4sBXEn1Knr6qVjFd7qNlUr4Rp3NnEh0uIb4AsQvwNqZVo3rB7l0K0hMoc7zzkqBy0GyF-IVXeeb5vma2A89g=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/XNuIaFkokZN8YsnFAM-oXDXxpo6ecqzi3IeK8wKiR394FRLYUaXCXrYQt8IiL0eKf7u_vUIkZ5VtCy_qV24-d6osoL53ZgjO-x5ug5g3-tQIjgrymxnTSE8OAtzyvC_VfAuwqy_N3w=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/zU_Ru6SDfn11KR654zlrCgwhhKql2edyVkN8fOTXzgU0gG5CaglW9uElS0YGTJoWRsq2moaoCrUAC43-fPGy2vE8KM0JG47CcApMIMEaK_-0YKZHBcV3fjlUXyD4kH3qAAjMK-mMBg=w1920-h1080"></object>
+                    <object data="https://lh3.googleusercontent.com/dVLhy3-QJqKmS9EvnDZ5ts-jjWncGj8qDUWrsyEd6rlCTEUF-CVbVCkiooVC7fIZijzoy48JdN2ylVET_f13Ly39wAznzhhsZ3CfJYtMKJ9Cl_KW-FYdd1cNxGJ8yCT3kbTFGX9w1Q=w1920-h1080"></object>
+                    </div>
+                </div>
+                <div class ="carousel">
+                    <div style = "top:50%;width:40vw;text-align:left;margin:15%;">
+                            Last year's tournament hosted over 80 people from across 3 states. 
+                            Great matches were played in all flights and we hope to replicate last years
+                            success and more at Fall 2019 UM Open.
+                    </div>
+                </div>
+        </div>
+
+    </div>
+
+
+    <div class = "schedule_row">
+        <div class = heading style = "text-align: center; font-size: 30px;padding-top: 30px;"> Schedule </div>
+        <div class = heading style = "text-align: center; font-size: 24px;padding-top: 30px;"> Saturday November 2nd </div>
+        <div class="event1"> 
+            <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                9:00am - 1:00pm
+            </div>
+            <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                M/W Singles (up to Quarters)
+            </div>
+        </div>
+        <div class="event2"> 
+            <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                1:00PM - 5:00PM
+            </div>
+            <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                M/W Doubles (up to Quarters)
+            </div>
+        </div>
+        <div class="event3"> 
+            <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                5:00PM -  8:00PM
+            </div>
+            <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                Mixed Doubles (up to Quarters)
+            </div>
+        </div>
+
+        <div class = heading style = "float: left;text-align: center; font-size: 24px;padding-top: 30px; width:100vw;"> Sunday November 3rd </div>
+
+        <div class="event5"> 
+                <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                    9:00am - 1:00pm
+                </div>
+                <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                    M/W Singles (Semifinals and Finals)
                 </div>
             </div>
-            <div class ="carousel">
-                <div style = "top:50%;width:40vw;text-align:left;margin:15%;">
-                        Last year's tournament hosted over 90 people from across 3 states. 
-                        Many great matches were played in all flights and we hope to replicate last years
-                        success and more with Fall 2019 UM Open.
+            <div class="event6"> 
+                <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                    1:00PM - 5:00PM
                 </div>
+                <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                    M/W Doubles (Semifinals and Finals)
+                </div>
+            </div>
+            <div class="event7"> 
+                <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                    5:00PM -  8:00PM
+                </div>
+                <div style = "width:50vw;float: left;text-align: center;padding-top:20px; padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                    Mixed Doubles (Semifinals and Finals)
+                </div>
+            </div>
+        <div class= "info">
+            <div style = "width:100vw;float: left;text-align: center;padding-top:20px;">
+                This schedule will be updated as the tournament progresses. Please check often for schedule updates.
+            </div>
+            <div style = "width:100vw;float: left;text-align: center;">
+                For specific times and information on brackets, please visit the tournament software page at
+            </div>
+            <div style = "width:100vw;float: left;text-align: center;padding-bottom: 20px; border-bottom: 1px solid rgb(31, 29, 29);">
+                <a href="https://www.tournamentsoftware.com/sport/draws.aspx?id=BA0F4119-A490-4E0B-9129-CDF0E4EF96CF">Tournament Software</a> 
             </div>
         </div>
     </div>
@@ -123,11 +197,10 @@
                  
             </p>
             <p class="content">
-            
-                Date: Friday November 20th - Sunday - November 22nd 
+                Date: Saturday November 2nd - Sunday November 3rd
             </p>
             <p class="content">
-                Time: 11:00-am - 4:00pm 
+                Time: 9:00-am - 4:00pm 
             </p>
             
             
@@ -143,16 +216,16 @@
 
         <div class="info_boxes_column">
             <h2>
-                Schedule
+                Contact
             </h2>
             <p>
-                Friday 4-9PM: Men's Doubles Ab
+                (insert email here)
             </p>
             <p>
-                Saturday 4-9PM: Women's Doubles Ab
+                (insert facebook here)
             </p>
             <p>
-                Sunday 4-9PM: Men's Doubles Ab
+                (insert ??? here)
             </p>
         </div>
     </div>

--- a/tournaments.html
+++ b/tournaments.html
@@ -39,72 +39,79 @@
     </div>
 
 
-    <div class="galleryrow">
+    <div style = "color:white;text-align:left;background-color: #00274C;font-size:40px">
             2019 Spring UM Open Gallery
+            
     </div>
-
-    <div class="tournament-gallery">
-        <div class="carousel">
-            <script src="https://cdn.jsdelivr.net/npm/publicalbum@latest/embed-ui.min.js" async></script>
-            <div class="pa-carousel-widget" style="width:50%; height:480px; display:none;"
-            data-link="https://photos.app.goo.gl/zQrj9tUEPfRN4rVBA"
-            data-title="UM OPEN 2019"
-            data-description="50 new photos added to shared album">
-            <object data="https://lh3.googleusercontent.com/loXDo_-a2dRGlEyme730FlvInNbpNrnob0wa8qPKf-JZD4CrVD-0UjlA2rop9Re6TuSpuL6i-eThS3lMem-DpJKwTkGKofXfi_9n1Ql-TBfY5IQCJ8ThhgodxGtKkSrVJAoHkoBITQ=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/RTz7ALX0Df_tu8oZJAVNmcV4V45PA1Erig9BMLNhiJvN6ruhL5JDF614mMlHm4p2yDrF8Lb-0OOCW3E_X_-3zMciZ6mBqBKqN5ZY9oadiPTlc9OabtdEzcHuHqcFePKxB9XXjBa2sw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/JNnri5rdLkb-MU_eE_JBLK7STI1ARoR_Rywwzj0QYBE1yzxDdNNa4mhluMkPo1mHHpETgDr_J0F5_BHF7qXwLEF75_6bKlubuDrVmpzAqLLL5xNkBC7xpVuKoEKwgwFQdV6AZUHEGw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/d8NPYN-n2nJAv4KJcqF--Z_yaomX546kiYFqeWZLKT2e1NNrij9P0iXnRiPgPe8uN21UH1MaAW_EgGQrSUlLs_THPBTVQ1RNz5SjeK7Yf-PouFYo0INx8IBiEmsuIjNX23WwEOWmlA=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/yJGjDdvj-8fDSty7EvxC5RpSAGuQEDuopy9iky3qrCQ9a1KhZQy2WZozVYr6wrD9KqxoJdJackVRE0HUzkg0WUGGBz62XaIqaG0h7M7oV8zwTuWdP1KS0znIFrBPjVpZMkB0t28u9w=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/yO8Y2V4vbu7uMP6nCY02A8NNF-dj1XLCDoNOe_1acK79rsrbQ-emWILHY6ZptUZp2hSOAT8nyDPyKvIX8k3zADwdl2B4wFRc-kESe81jOVKKBpSogzDpsZPjxBC98-7aBxp9G6aXuQ=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/2j76CYefADOHnDUatKQhhDS5Zp9lXgi6wj9R8V1Lxiv5DOR3Q4VSBUfySGzLglxiT-gJFcMTSx3KKdoH2RzJtfMjgkbAGXpNtwAZOaAh6Nj4KKljFyx2Ii_40pLYAl7E7-IPi9FrZg=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/XjngG5GRWJF9w6bAM26WH6Zak0la6GSJvdSbIRnq9G5MCQw0jvKjLc5nf1LUGQzSg92Ss9FprN6QWBdAyOK-cff1d7CeJe0tpbZgBcheGQ-E-xqF41DybmYSd0V_1apJ2hB-qBgPQw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/gx92vkAVOnKyXxFh-WxWZVoGswkMVNnKcia4SUKtmQGIFtACtJdQpNNAP__rzzH0CWMXeqfjT-CbERZVHgPVICmrQakBRuZJcIE81TbwV0vYGMgtOvGq8l7I0hoaBZU7VYgK11iDwQ=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/sz85YaOw8yhCSg4cEDCytzCfU_hbENm35KmjBewWMjmbcK0JQszAjYtPpbMHlW00fYQRttj6X0Js3UJ_TblcASnpKELSo1QeGY-Z5gEYwVfV62KZ9gWgjRS11gFkNiHS1zr6o4Rp0w=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/O8fBXZJNxEAYXsbSL9hhO1Nktpkx_QMHhjYQLn0pgOPrVPpS36-2IS-mRaKr8GLiiq0-hddyWh6QAvVfDtOCSemQeIn5N9IJdEfSxMhbGXH8qEpFzGk8TYwdGc60BTEAxlKr9uVXhw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/Oezyk3C_AQmn_LxItSMcch3xzCM1WyjBbrmPJshacFn25-4vO_dKDk2RG-QMqwYcZesk5-2Foo9ci_4-R5Ahy4d1-Uttycr2_36jEFUV5MVcr1PACrLnwtDHgqPHoAtc0mh4UphNDw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/7TXIFekjgheNdq0ympCH3NItu-YrEask5l7XQ78KZEk44ktF1lgc7CdA4D6eyz-z5-lDXE3PPEaBnp60az-U8lXSwMlYctN0znasx5d0OuNbdZKFwa231UI-3kujtuEnxymbA2WkWw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/55ojdq6x9HTQkP9p3IOVfyXemtYlTtgKAVGVeyW1FqOB-FawkGS25F-XsdzjxvikzFR_5VrPUJkJcYYx6XhnVrXkXIRFbi8ST8s4grhL90UV8adA9yl0DcCzB2qZg55JVO0TFxDRNg=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/pxE2ztjaPUqua6gM7mPxMFQ_Bv2_3xzipMtYw9z6zXBN2aqukZrPPZ1HwB2uwi6lom4kbMJQ2cWbc6Cf-uJWzEDzBsqfacfkMq03-KEk1_Mw2E7E5KoDoHEy9wx_kFprTvFg4wRaww=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/7a0xlZ2WLDfNxYtORJNO4LDeMg9_VT7rk-ne-j0bHssjeN3RV_bpzhONKd9ABFU0GENVs7hvv9_mfEuIYjuM6gd3hNPmvgBlxAgBvsHBbDIp3ufe7XFcHCnVYZ9nvoOynlSInfXE_g=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/d12WwhDOgR_2vZfHSqHFE5gnFSmsqFJ_8vfaEYlodKWEMuaGe2wWNXyLVHK_gFjzMPmQKKRuvCPIY-X5cGx0-XUnXWcJ7sHmSa0Zjrbm1fHBQNqxr-9D6FRpjNMVaOu3JoH9y6sM4g=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/FyTKpP0XK1w-A6mpIr-n950JJwPliTE-lnrf_PJjehaDK8PDsA8kRcdPoOoSdUYv6hVwtnU8-TaXuyJ7u8SN0ZX6zcoIrdb72X_L_JwY39OrJ19RyJP9u2JTD1bRhBctlhuFtM20Og=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/B0NUFEH4MQK_1-ubU3e6KU34AigvoE8txIh0Nk2ISPVXCGZj8Y-iJz5lrvFPORJmwvLOkHO9efggNkJVlpWfijkyjTB2oUVKT5n-ky1u0bPjDtuZgcbDE_HIJhS3NuwjHmaU5453vQ=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/OwJIw_YCmJtmJKYnv06ZGnIp53XEqrZ1zg73KdCuI43-AWMzWlRCugPzR8PrzmWdRa1reU7LRt0NUEjxQhlvNyuUuFwMlb19ehFLJPh7_-hbFOY-SxG0Y9K1rZ2Fs-xB0-DfsW3NIg=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/lgpJUL6WhhzMh4E9mP8QYABV1fPuaxtBmN1IJFEQaGK8vs9Qd_cGAJ9bfcBkQwLP845D1qj1P3QlSevzqIAnl9rHHvaBRXccMQyG1mscnA8wg6L2cCd7HPR4xjjaAAvRnUDCJLe3WA=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/ayLnJhrL80QJo8MaA5LmKYO1UpeSQbI-Yc16YI1EzlIGs1SjJUL25vE2zLWY0X2ja2q14rdjf5xdO4jOqtNrG6u2sUi8_igkhCBrPTPEvTfTbCtiAQLzHrOy-VstMiFpmQgWKeoEDg=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/QeIUn5hdYjT7az1Pm_2QxVTkxHcgPl14iq-ZxyU72LFdB_6iiOEdK6bm1vPoHjnDxALctS_Igugis1egmxeXqdS4BRxEgVIqq6oRHT4wr6aE2wCgSio_weVGN8T8uN84TOjdeIFKWQ=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/XsnFiIXT7b8qcRem0JEpsq0SdDatYgYe43UxR3Sj1Cn2wgQoURFXaDR5eVKyv2VNDK6gQIhMKL_juPXssfavZDv7Rgf_fgk2Nn8_zOuUqY3Bir6KVTNz-dlC93i13aPPEvO9BFXAVQ=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/eZ0xJuSLOCRYL74VHPsFNTRO2ma41bRHRnNLjpVYMqeaPZc9Z6uNLXvVdKn8Z06kM8flxOVaCrEcmE6PvQ6I6z4pQctlHHGUAG11Wos-KyO4Rp-1h_U28KLlwEXbkbI6qfU-oIqfSw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/qGWXkq54NoKodT8fNDJgdaW1qajMEFQ1EwrWwIi0_JA3oks-3Seuv6DbH7N4dDxr-R0o33xH9b-4oP8P808LkmWhR8ybo1fVkzSSrpi3DfxvMKn6YSklp7-3U_ulSOZr5_4-Zjs__g=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/h4U5DMmYYk1CqxAXoCFRQiGvXZAPqqHKzjCBWqzd8OE88eYpFVav8loPR30ST4bhw359Q4llJLRpdW92-Cz0pn-P9uvkwU07mwonojS5tO10MLS36ZdSLmf4idx2IxzlGK_yUYgdlw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/vO_94PlPzY9beHQsQeMPn7s-5ZssDuDvZPqiKOzxITLkL-w66KQTpwPhnZtqHOlA2eHQKqnUnx4RiwmS6E5KP5bFqexuuYxzikKOEnD_nfgjkLV_xIiEt5BgOt6KNBLrkHDd5lswUw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/eHTev9asEinRI0LhtUGryuc2VOgsnLaowYaK3SXcZHJ6r3TX3iZHBnqt4oweladMh8x_fNbgwcDn-gNItiKuooH2Iqh90nK3T4KvAfBvwBGhwfS8LWnmT-yp8hzqBsl-KcxA4j57bQ=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/AUJr6RSGEm5FAiAxlMf15EjQaJtDjc2s7HqZ_NYj7Ho_R00m7arH802u6sUi1XiC9Mnamd3tGI5GEfZu5amkAMUAP9ooUDatlTmwfyDw6oV5hpxAGgHVGjUubqrgJkYsC33U4DIgMg=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/AfBOLg3L7LxIBpzkneIMImNGxZI5NifQ0lLPcuG34Mw7RbxePAJXUDgcc1ifqBaZUIj1KJbx322mnM-Nyd6VWEe_7JvbG97EQGbkxVdeILYdnfTYAL9xSBie9sZsjeDpaX-eM6zrjA=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/9R40cGOFmrfGGCk8fyWkPQY81_ctctGTUWYHoz6-e35-x1OuPyvAiu3rLMWkdJoLX_eJDkOwHK8omeJw02F5gwff7dkda0uqH-keu2AEYZ784c4KBTBAFIg5TG8GSSQx0am3zfyjhA=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/6RmuTxBJvWLSt3rVwPwyqo6-dHC7zQkMggVQauNz09NG2gLy3NECkBd3ueFfk3YghJbdW19a8AF66dJxjrhofYeo9BpAC5_dUA6DaV_8GgiBZbsOzJwhkOp1tcgV0YE1uf1hWv5Mqg=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/abTUFqOcFCmSzpm82vg0LaSWkM__d1q5HM-wCl76DURC6MxE3tILERN37Q8QCfc0tfxdwSRtZDbQx8oPWNp6OD0-Yq0eowztfGWT2eBZg_EtKdhN9uWlbLvLdyYirQU1cuNRQ_T89w=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/frOsz7Q6qYC789x4Se2VwPAkWyxf3J49lT7TSDB1dyO-63DIRHLQYbY9G6C8JzTTQoGOR7HKZ7Sb4tsqLuik7xabBBnbRxM4X2oy7azPbga6IZaBSPEBGWrCU3-XsEPLKBVF3xaNMA=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/y1UpBCvn0jdBnRIJMwyA2W3mv3na-jOi1Dod3-GEM7A6RPggCk2yEw2sH0DGE7m0NAKxX5S9pfI7b1ORZMAunbopYzQIGmdGhYfseG358ZUj1cWJm7m-ltju0VbTWvAJBRm-np-4tw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/RAzJWbdO6PbGCGZQgKcsf-QfpJBhC5LIY7yPfdij-f7GvYq5ft5gVL5dAGySJLaewijafBK4SotSdwxbjCI8E81nMJRQeSgVy9yZ_a2vCioZSCt7OB8KwXHd1ajNc6OKo6Y4h8-MZg=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/M52alzzCnnfjZpIF5k97i-smKmvESDYW8NQM5LPzvLlRXGlGWk0NQD9ZRsro1Vhig129x4jRhUEOtKXvqiPfJSmdBIwlzpM6dQ561PkFxJXRlMqHOyjLLFVa1mJY8jOFKb_JU_-Shw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/o9q4T9QpA6OsCQxSE-4UsAiLCeX2IvWKu19coNB5BvYJTjE9kMkG9YinaQ20yHBVuqI1ADMewlO-TkgnZ4852KKiSvD8thojkcnR5Q9DhUd7NkgqWUd90z3FoxOlqUCvA0fGT_tCtw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/UVqi0unETx7GGzxOeqOvvAPuv8msFUyceKT0KUEioRQV8yQvitIZqcbeZuH9Z2u0MS9Ri_RTK8tELh4h8Xwle-ND6P0iuI-okChJ9F5As7cmx_TgTEqFEgBoaWxeOMl0gPddpLJ_Pg=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/Zh_6a71TKy1X5bK3LYvJUExaCvN9eUfhWmgJLptd8V4DRHccMQ73VNuj3Y6ptWrfDQF0MJg0aJ_LuzLB_Iq1Gq2zvD5FqpZXKLHVV0F3tVUJ0fRPIitABRJbvwySyaIU0FcciSNJSw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/nzcoL1pYBrCzvC4Y7gR7RwTSMDdr_S26Q3cVfMd5RNPm3bySVH1DZweypS2BY45A_Pk328GhZhx86iygVAYbMcB6GlvRQQ6rjoy_id0C7buGzdGQTA-3ycaATEYMtj4uk1z2MgUJKQ=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/TxKIKPbusTL3vkWbZ1dV_iPU8QVw05NI9erjf1_WMu9ZdptDs8Sb-O75_zXuYpfXhWiQH-yZrsxnRo-NP70GurXBjb5P3_vOyDZCnilh8ocWQIEmR4P91s0QL_Yi4tL0sEoBG8rueA=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/eF9tz2zmaMVAIrVEGeqwsPR01p_1Dqb-MakHDQSfXO4gDViqvGNYvmf411YRiR_22TyaRKS6rzS6ig2uLCcvHoSojJRuyeaaRe9FSb3-Dq0lirMb4V35BwNIbC4n6s0b5Ni1PLilSw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/II5i8tHUZ_zxax3QIe0FVXDLq2LbSIS_UBv4_trSsNI2Sw5Woq1D5ht2TCmXMB75C-Jpr95gppMiQxG6IanwhDKUw0aLFfEzly4MWmjN_IK38K8nU6s9RA0NAs7aPaQOR1G1N-ELSA=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/6KF2dx1EVKUFsqvYTlerVUk6v3pha8itDT1cfNFrK8v3t384uUS-sms-m4gEY20hOjKgZNBq0fm2qidZrCVo9Pda482Ou-OT1C6TeawtLOMjhsiJePO4eenAyicQRXF-KYVZQcrhSw=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/vYT3WBmKD8ePyeka6ru6PrmNyPDdXhS9ebZJjNI0ReFN4ehSGVIWGj4sBXEn1Knr6qVjFd7qNlUr4Rp3NnEh0uIb4AsQvwNqZVo3rB7l0K0hMoc7zzkqBy0GyF-IVXeeb5vma2A89g=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/XNuIaFkokZN8YsnFAM-oXDXxpo6ecqzi3IeK8wKiR394FRLYUaXCXrYQt8IiL0eKf7u_vUIkZ5VtCy_qV24-d6osoL53ZgjO-x5ug5g3-tQIjgrymxnTSE8OAtzyvC_VfAuwqy_N3w=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/zU_Ru6SDfn11KR654zlrCgwhhKql2edyVkN8fOTXzgU0gG5CaglW9uElS0YGTJoWRsq2moaoCrUAC43-fPGy2vE8KM0JG47CcApMIMEaK_-0YKZHBcV3fjlUXyD4kH3qAAjMK-mMBg=w1920-h1080"></object>
-            <object data="https://lh3.googleusercontent.com/dVLhy3-QJqKmS9EvnDZ5ts-jjWncGj8qDUWrsyEd6rlCTEUF-CVbVCkiooVC7fIZijzoy48JdN2ylVET_f13Ly39wAznzhhsZ3CfJYtMKJ9Cl_KW-FYdd1cNxGJ8yCT3kbTFGX9w1Q=w1920-h1080"></object>
+        <div class = "tournament-gallery">
+        <div class="tournament-gallery2">
+            <div class="carousel">
+                <script src="https://cdn.jsdelivr.net/npm/publicalbum@latest/embed-ui.min.js" async></script>
+                <div class="pa-carousel-widget" style="width:50vw; height:480px; display:none;"
+                data-link="https://photos.app.goo.gl/zQrj9tUEPfRN4rVBA"
+                data-title="UM OPEN 2019"
+                data-description="50 new photos added to shared album">
+                <object data="https://lh3.googleusercontent.com/loXDo_-a2dRGlEyme730FlvInNbpNrnob0wa8qPKf-JZD4CrVD-0UjlA2rop9Re6TuSpuL6i-eThS3lMem-DpJKwTkGKofXfi_9n1Ql-TBfY5IQCJ8ThhgodxGtKkSrVJAoHkoBITQ=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/RTz7ALX0Df_tu8oZJAVNmcV4V45PA1Erig9BMLNhiJvN6ruhL5JDF614mMlHm4p2yDrF8Lb-0OOCW3E_X_-3zMciZ6mBqBKqN5ZY9oadiPTlc9OabtdEzcHuHqcFePKxB9XXjBa2sw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/JNnri5rdLkb-MU_eE_JBLK7STI1ARoR_Rywwzj0QYBE1yzxDdNNa4mhluMkPo1mHHpETgDr_J0F5_BHF7qXwLEF75_6bKlubuDrVmpzAqLLL5xNkBC7xpVuKoEKwgwFQdV6AZUHEGw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/d8NPYN-n2nJAv4KJcqF--Z_yaomX546kiYFqeWZLKT2e1NNrij9P0iXnRiPgPe8uN21UH1MaAW_EgGQrSUlLs_THPBTVQ1RNz5SjeK7Yf-PouFYo0INx8IBiEmsuIjNX23WwEOWmlA=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/yJGjDdvj-8fDSty7EvxC5RpSAGuQEDuopy9iky3qrCQ9a1KhZQy2WZozVYr6wrD9KqxoJdJackVRE0HUzkg0WUGGBz62XaIqaG0h7M7oV8zwTuWdP1KS0znIFrBPjVpZMkB0t28u9w=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/yO8Y2V4vbu7uMP6nCY02A8NNF-dj1XLCDoNOe_1acK79rsrbQ-emWILHY6ZptUZp2hSOAT8nyDPyKvIX8k3zADwdl2B4wFRc-kESe81jOVKKBpSogzDpsZPjxBC98-7aBxp9G6aXuQ=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/2j76CYefADOHnDUatKQhhDS5Zp9lXgi6wj9R8V1Lxiv5DOR3Q4VSBUfySGzLglxiT-gJFcMTSx3KKdoH2RzJtfMjgkbAGXpNtwAZOaAh6Nj4KKljFyx2Ii_40pLYAl7E7-IPi9FrZg=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/XjngG5GRWJF9w6bAM26WH6Zak0la6GSJvdSbIRnq9G5MCQw0jvKjLc5nf1LUGQzSg92Ss9FprN6QWBdAyOK-cff1d7CeJe0tpbZgBcheGQ-E-xqF41DybmYSd0V_1apJ2hB-qBgPQw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/gx92vkAVOnKyXxFh-WxWZVoGswkMVNnKcia4SUKtmQGIFtACtJdQpNNAP__rzzH0CWMXeqfjT-CbERZVHgPVICmrQakBRuZJcIE81TbwV0vYGMgtOvGq8l7I0hoaBZU7VYgK11iDwQ=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/sz85YaOw8yhCSg4cEDCytzCfU_hbENm35KmjBewWMjmbcK0JQszAjYtPpbMHlW00fYQRttj6X0Js3UJ_TblcASnpKELSo1QeGY-Z5gEYwVfV62KZ9gWgjRS11gFkNiHS1zr6o4Rp0w=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/O8fBXZJNxEAYXsbSL9hhO1Nktpkx_QMHhjYQLn0pgOPrVPpS36-2IS-mRaKr8GLiiq0-hddyWh6QAvVfDtOCSemQeIn5N9IJdEfSxMhbGXH8qEpFzGk8TYwdGc60BTEAxlKr9uVXhw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/Oezyk3C_AQmn_LxItSMcch3xzCM1WyjBbrmPJshacFn25-4vO_dKDk2RG-QMqwYcZesk5-2Foo9ci_4-R5Ahy4d1-Uttycr2_36jEFUV5MVcr1PACrLnwtDHgqPHoAtc0mh4UphNDw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/7TXIFekjgheNdq0ympCH3NItu-YrEask5l7XQ78KZEk44ktF1lgc7CdA4D6eyz-z5-lDXE3PPEaBnp60az-U8lXSwMlYctN0znasx5d0OuNbdZKFwa231UI-3kujtuEnxymbA2WkWw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/55ojdq6x9HTQkP9p3IOVfyXemtYlTtgKAVGVeyW1FqOB-FawkGS25F-XsdzjxvikzFR_5VrPUJkJcYYx6XhnVrXkXIRFbi8ST8s4grhL90UV8adA9yl0DcCzB2qZg55JVO0TFxDRNg=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/pxE2ztjaPUqua6gM7mPxMFQ_Bv2_3xzipMtYw9z6zXBN2aqukZrPPZ1HwB2uwi6lom4kbMJQ2cWbc6Cf-uJWzEDzBsqfacfkMq03-KEk1_Mw2E7E5KoDoHEy9wx_kFprTvFg4wRaww=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/7a0xlZ2WLDfNxYtORJNO4LDeMg9_VT7rk-ne-j0bHssjeN3RV_bpzhONKd9ABFU0GENVs7hvv9_mfEuIYjuM6gd3hNPmvgBlxAgBvsHBbDIp3ufe7XFcHCnVYZ9nvoOynlSInfXE_g=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/d12WwhDOgR_2vZfHSqHFE5gnFSmsqFJ_8vfaEYlodKWEMuaGe2wWNXyLVHK_gFjzMPmQKKRuvCPIY-X5cGx0-XUnXWcJ7sHmSa0Zjrbm1fHBQNqxr-9D6FRpjNMVaOu3JoH9y6sM4g=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/FyTKpP0XK1w-A6mpIr-n950JJwPliTE-lnrf_PJjehaDK8PDsA8kRcdPoOoSdUYv6hVwtnU8-TaXuyJ7u8SN0ZX6zcoIrdb72X_L_JwY39OrJ19RyJP9u2JTD1bRhBctlhuFtM20Og=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/B0NUFEH4MQK_1-ubU3e6KU34AigvoE8txIh0Nk2ISPVXCGZj8Y-iJz5lrvFPORJmwvLOkHO9efggNkJVlpWfijkyjTB2oUVKT5n-ky1u0bPjDtuZgcbDE_HIJhS3NuwjHmaU5453vQ=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/OwJIw_YCmJtmJKYnv06ZGnIp53XEqrZ1zg73KdCuI43-AWMzWlRCugPzR8PrzmWdRa1reU7LRt0NUEjxQhlvNyuUuFwMlb19ehFLJPh7_-hbFOY-SxG0Y9K1rZ2Fs-xB0-DfsW3NIg=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/lgpJUL6WhhzMh4E9mP8QYABV1fPuaxtBmN1IJFEQaGK8vs9Qd_cGAJ9bfcBkQwLP845D1qj1P3QlSevzqIAnl9rHHvaBRXccMQyG1mscnA8wg6L2cCd7HPR4xjjaAAvRnUDCJLe3WA=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/ayLnJhrL80QJo8MaA5LmKYO1UpeSQbI-Yc16YI1EzlIGs1SjJUL25vE2zLWY0X2ja2q14rdjf5xdO4jOqtNrG6u2sUi8_igkhCBrPTPEvTfTbCtiAQLzHrOy-VstMiFpmQgWKeoEDg=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/QeIUn5hdYjT7az1Pm_2QxVTkxHcgPl14iq-ZxyU72LFdB_6iiOEdK6bm1vPoHjnDxALctS_Igugis1egmxeXqdS4BRxEgVIqq6oRHT4wr6aE2wCgSio_weVGN8T8uN84TOjdeIFKWQ=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/XsnFiIXT7b8qcRem0JEpsq0SdDatYgYe43UxR3Sj1Cn2wgQoURFXaDR5eVKyv2VNDK6gQIhMKL_juPXssfavZDv7Rgf_fgk2Nn8_zOuUqY3Bir6KVTNz-dlC93i13aPPEvO9BFXAVQ=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/eZ0xJuSLOCRYL74VHPsFNTRO2ma41bRHRnNLjpVYMqeaPZc9Z6uNLXvVdKn8Z06kM8flxOVaCrEcmE6PvQ6I6z4pQctlHHGUAG11Wos-KyO4Rp-1h_U28KLlwEXbkbI6qfU-oIqfSw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/qGWXkq54NoKodT8fNDJgdaW1qajMEFQ1EwrWwIi0_JA3oks-3Seuv6DbH7N4dDxr-R0o33xH9b-4oP8P808LkmWhR8ybo1fVkzSSrpi3DfxvMKn6YSklp7-3U_ulSOZr5_4-Zjs__g=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/h4U5DMmYYk1CqxAXoCFRQiGvXZAPqqHKzjCBWqzd8OE88eYpFVav8loPR30ST4bhw359Q4llJLRpdW92-Cz0pn-P9uvkwU07mwonojS5tO10MLS36ZdSLmf4idx2IxzlGK_yUYgdlw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/vO_94PlPzY9beHQsQeMPn7s-5ZssDuDvZPqiKOzxITLkL-w66KQTpwPhnZtqHOlA2eHQKqnUnx4RiwmS6E5KP5bFqexuuYxzikKOEnD_nfgjkLV_xIiEt5BgOt6KNBLrkHDd5lswUw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/eHTev9asEinRI0LhtUGryuc2VOgsnLaowYaK3SXcZHJ6r3TX3iZHBnqt4oweladMh8x_fNbgwcDn-gNItiKuooH2Iqh90nK3T4KvAfBvwBGhwfS8LWnmT-yp8hzqBsl-KcxA4j57bQ=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/AUJr6RSGEm5FAiAxlMf15EjQaJtDjc2s7HqZ_NYj7Ho_R00m7arH802u6sUi1XiC9Mnamd3tGI5GEfZu5amkAMUAP9ooUDatlTmwfyDw6oV5hpxAGgHVGjUubqrgJkYsC33U4DIgMg=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/AfBOLg3L7LxIBpzkneIMImNGxZI5NifQ0lLPcuG34Mw7RbxePAJXUDgcc1ifqBaZUIj1KJbx322mnM-Nyd6VWEe_7JvbG97EQGbkxVdeILYdnfTYAL9xSBie9sZsjeDpaX-eM6zrjA=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/9R40cGOFmrfGGCk8fyWkPQY81_ctctGTUWYHoz6-e35-x1OuPyvAiu3rLMWkdJoLX_eJDkOwHK8omeJw02F5gwff7dkda0uqH-keu2AEYZ784c4KBTBAFIg5TG8GSSQx0am3zfyjhA=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/6RmuTxBJvWLSt3rVwPwyqo6-dHC7zQkMggVQauNz09NG2gLy3NECkBd3ueFfk3YghJbdW19a8AF66dJxjrhofYeo9BpAC5_dUA6DaV_8GgiBZbsOzJwhkOp1tcgV0YE1uf1hWv5Mqg=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/abTUFqOcFCmSzpm82vg0LaSWkM__d1q5HM-wCl76DURC6MxE3tILERN37Q8QCfc0tfxdwSRtZDbQx8oPWNp6OD0-Yq0eowztfGWT2eBZg_EtKdhN9uWlbLvLdyYirQU1cuNRQ_T89w=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/frOsz7Q6qYC789x4Se2VwPAkWyxf3J49lT7TSDB1dyO-63DIRHLQYbY9G6C8JzTTQoGOR7HKZ7Sb4tsqLuik7xabBBnbRxM4X2oy7azPbga6IZaBSPEBGWrCU3-XsEPLKBVF3xaNMA=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/y1UpBCvn0jdBnRIJMwyA2W3mv3na-jOi1Dod3-GEM7A6RPggCk2yEw2sH0DGE7m0NAKxX5S9pfI7b1ORZMAunbopYzQIGmdGhYfseG358ZUj1cWJm7m-ltju0VbTWvAJBRm-np-4tw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/RAzJWbdO6PbGCGZQgKcsf-QfpJBhC5LIY7yPfdij-f7GvYq5ft5gVL5dAGySJLaewijafBK4SotSdwxbjCI8E81nMJRQeSgVy9yZ_a2vCioZSCt7OB8KwXHd1ajNc6OKo6Y4h8-MZg=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/M52alzzCnnfjZpIF5k97i-smKmvESDYW8NQM5LPzvLlRXGlGWk0NQD9ZRsro1Vhig129x4jRhUEOtKXvqiPfJSmdBIwlzpM6dQ561PkFxJXRlMqHOyjLLFVa1mJY8jOFKb_JU_-Shw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/o9q4T9QpA6OsCQxSE-4UsAiLCeX2IvWKu19coNB5BvYJTjE9kMkG9YinaQ20yHBVuqI1ADMewlO-TkgnZ4852KKiSvD8thojkcnR5Q9DhUd7NkgqWUd90z3FoxOlqUCvA0fGT_tCtw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/UVqi0unETx7GGzxOeqOvvAPuv8msFUyceKT0KUEioRQV8yQvitIZqcbeZuH9Z2u0MS9Ri_RTK8tELh4h8Xwle-ND6P0iuI-okChJ9F5As7cmx_TgTEqFEgBoaWxeOMl0gPddpLJ_Pg=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/Zh_6a71TKy1X5bK3LYvJUExaCvN9eUfhWmgJLptd8V4DRHccMQ73VNuj3Y6ptWrfDQF0MJg0aJ_LuzLB_Iq1Gq2zvD5FqpZXKLHVV0F3tVUJ0fRPIitABRJbvwySyaIU0FcciSNJSw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/nzcoL1pYBrCzvC4Y7gR7RwTSMDdr_S26Q3cVfMd5RNPm3bySVH1DZweypS2BY45A_Pk328GhZhx86iygVAYbMcB6GlvRQQ6rjoy_id0C7buGzdGQTA-3ycaATEYMtj4uk1z2MgUJKQ=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/TxKIKPbusTL3vkWbZ1dV_iPU8QVw05NI9erjf1_WMu9ZdptDs8Sb-O75_zXuYpfXhWiQH-yZrsxnRo-NP70GurXBjb5P3_vOyDZCnilh8ocWQIEmR4P91s0QL_Yi4tL0sEoBG8rueA=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/eF9tz2zmaMVAIrVEGeqwsPR01p_1Dqb-MakHDQSfXO4gDViqvGNYvmf411YRiR_22TyaRKS6rzS6ig2uLCcvHoSojJRuyeaaRe9FSb3-Dq0lirMb4V35BwNIbC4n6s0b5Ni1PLilSw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/II5i8tHUZ_zxax3QIe0FVXDLq2LbSIS_UBv4_trSsNI2Sw5Woq1D5ht2TCmXMB75C-Jpr95gppMiQxG6IanwhDKUw0aLFfEzly4MWmjN_IK38K8nU6s9RA0NAs7aPaQOR1G1N-ELSA=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/6KF2dx1EVKUFsqvYTlerVUk6v3pha8itDT1cfNFrK8v3t384uUS-sms-m4gEY20hOjKgZNBq0fm2qidZrCVo9Pda482Ou-OT1C6TeawtLOMjhsiJePO4eenAyicQRXF-KYVZQcrhSw=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/vYT3WBmKD8ePyeka6ru6PrmNyPDdXhS9ebZJjNI0ReFN4ehSGVIWGj4sBXEn1Knr6qVjFd7qNlUr4Rp3NnEh0uIb4AsQvwNqZVo3rB7l0K0hMoc7zzkqBy0GyF-IVXeeb5vma2A89g=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/XNuIaFkokZN8YsnFAM-oXDXxpo6ecqzi3IeK8wKiR394FRLYUaXCXrYQt8IiL0eKf7u_vUIkZ5VtCy_qV24-d6osoL53ZgjO-x5ug5g3-tQIjgrymxnTSE8OAtzyvC_VfAuwqy_N3w=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/zU_Ru6SDfn11KR654zlrCgwhhKql2edyVkN8fOTXzgU0gG5CaglW9uElS0YGTJoWRsq2moaoCrUAC43-fPGy2vE8KM0JG47CcApMIMEaK_-0YKZHBcV3fjlUXyD4kH3qAAjMK-mMBg=w1920-h1080"></object>
+                <object data="https://lh3.googleusercontent.com/dVLhy3-QJqKmS9EvnDZ5ts-jjWncGj8qDUWrsyEd6rlCTEUF-CVbVCkiooVC7fIZijzoy48JdN2ylVET_f13Ly39wAznzhhsZ3CfJYtMKJ9Cl_KW-FYdd1cNxGJ8yCT3kbTFGX9w1Q=w1920-h1080"></object>
+                </div>
+            </div>
+            <div class ="carousel">
+                <div style = "top:50%;width:40vw;text-align:left;margin:15%;">
+                        Last year's tournament hosted over 90 people from across 3 states. 
+                        Many great matches were played in all flights and we hope to replicate last years
+                        success and more with Fall 2019 UM Open.
+                </div>
             </div>
         </div>
-
     </div>
-    
 
     <div class="info_boxes_row">
         <div class="info_boxes_column">
@@ -139,8 +146,13 @@
                 Schedule
             </h2>
             <p>
-                Location: Ann Arbor,  MI
-                Time: 2:00am - 4:00am 
+                Friday 4-9PM: Men's Doubles Ab
+            </p>
+            <p>
+                Saturday 4-9PM: Women's Doubles Ab
+            </p>
+            <p>
+                Sunday 4-9PM: Men's Doubles Ab
             </p>
         </div>
     </div>


### PR DESCRIPTION
The work in this branch consists of establishing most of the basic content and template of the tournaments page. The tournament page now has the following:

-Blurry background + title (with basic css parallax effect) 
-Gallery of images of last year's tournament
-Area for basic tournament information (including embedded google map)

Note that there is still placeholder text to change and there may be rearrangements of elements of the page in the future, but it is complete in terms of being a basic template.

This establishes a basic template for the tournament page, which is previously empty. 

Below is are screenshots of the how the page looks.
<img width="1432" alt="Screen Shot 2019-10-19 at 8 47 20 PM" src="https://user-images.githubusercontent.com/55893673/67153107-ad2c3700-f2b1-11e9-9edb-ea75a66319b9.png">

<img width="1440" alt="Screen Shot 2019-10-19 at 8 47 12 PM" src="https://user-images.githubusercontent.com/55893673/67153114-ba492600-f2b1-11e9-8378-bf097d7e28ab.png">

